### PR TITLE
Improve performance of progressbar and saving to file

### DIFF
--- a/examples/basic_sphere.rs
+++ b/examples/basic_sphere.rs
@@ -74,7 +74,7 @@ fn main() {
     world.add_sphere(sphere_3);
     world.add_sphere(sphere_4);
 
-    let bar = ProgressBar::new(nx*ny);
+    let bar = ProgressBar::new(ny);
     bar.set_style(ProgressStyle::default_bar().template("[{elapsed} elapsed] {wide_bar:.cyan/white} {percent}% [{eta} remaining] [rendering]"));
 
     let scene: Vec<Vec<Vec3>> = (0..ny).into_par_iter().map(|y_rev| {
@@ -90,9 +90,9 @@ fn main() {
             color_vector = color_vector/ns as f64;
             color_vector = 255.99*Vec3::new(color_vector.r().sqrt(), color_vector.g().sqrt(), color_vector.b().sqrt());
             color_vector.colorize();
-            bar.inc(1);
             color_vector
         }).collect();
+        bar.inc(1);
         row
     }).collect();
 

--- a/examples/one_weekend.rs
+++ b/examples/one_weekend.rs
@@ -100,7 +100,7 @@ fn main() {
 
     let world: HittableList = random_scene();
 
-    let bar = ProgressBar::new(nx*ny);
+    let bar = ProgressBar::new(ny);
     bar.set_style(ProgressStyle::default_bar().template("[{elapsed} elapsed] {wide_bar:.cyan/white} {percent}% [{eta} remaining] [rendering]"));
 
     let scene: Vec<Vec<Vec3>> = (0..ny).into_par_iter().map(|y_rev| {
@@ -116,9 +116,9 @@ fn main() {
             color_vector = color_vector/ns as f64;
             color_vector = 255.99*Vec3::new(color_vector.r().sqrt(), color_vector.g().sqrt(), color_vector.b().sqrt());
             color_vector.colorize();
-            bar.inc(1);
             color_vector
         }).collect();
+        bar.inc(1);
         row
     }).collect();
 

--- a/src/io/write.rs
+++ b/src/io/write.rs
@@ -23,7 +23,7 @@ pub fn gen_ppm(image: Vec<Vec<Vec3>>, filename: String) -> () {
 
     write!(file, "P3\n{} {}\n255\n", image[0].len(), image.len()).expect("saving to file failed.");
 
-    let bar = ProgressBar::new((image.len() * image[0].len()) as u64);
+    let bar = ProgressBar::new((image.len()) as u64);
     bar.set_style(ProgressStyle::default_bar().template(
         "[{elapsed} elapsed] {wide_bar:.cyan/white} {percent}% [{eta} remaining]    [saving]",
     ));
@@ -31,8 +31,8 @@ pub fn gen_ppm(image: Vec<Vec<Vec3>>, filename: String) -> () {
     for row in image {
         for pixel in row {
             write!(file, "{} {} {}\n", pixel.r(), pixel.g(), pixel.b()).expect("saving to file failed.");
-            bar.inc(1);
         }
+        bar.inc(1);
     }
 
     bar.finish();


### PR DESCRIPTION
After doing some testing, doing per-pixel progressbar seemed like a 15% hit on performance, so this code only updates the progressbar after each row, which still provides plenty of information.

This also changes the `gen_ppm` function to save each pixel directly to the file, rather than constantly expanding a String buffer in a loop to hold the (somewhat) enormous text-representation of the pixel information. I think this makes it noticeably faster, and it's better for memory usage.