### PR TITLE
fix call to DynamicImage.save methode

### DIFF
--- a/src/io/write.rs
+++ b/src/io/write.rs
@@ -1,18 +1,17 @@
 extern crate image;
 
-use structures::vec3::Vec3;
 #[cfg(test)]
 use structures::ray::Ray;
+use structures::vec3::Vec3;
 
 use std::error::Error;
-use std::io::prelude::*;
 use std::fs::File;
+use std::io::prelude::*;
 use std::path::Path;
 
 use indicatif::{ProgressBar, ProgressStyle};
 
 pub fn gen_ppm(img: Vec<Vec<Vec3>>, filename: String) -> () {
-
     // Time to write to image file!
     let path = Path::new(&filename);
     let display = path.display();
@@ -27,14 +26,17 @@ pub fn gen_ppm(img: Vec<Vec<Vec3>>, filename: String) -> () {
 
     for (y, row) in img.iter().enumerate() {
         for (x, pixel) in row.iter().enumerate() {
-            imgbuf.put_pixel(x as u32, y as u32, image::Rgb([pixel.r() as u8, pixel.g() as u8, pixel.b() as u8]));
+            imgbuf.put_pixel(
+                x as u32,
+                y as u32,
+                image::Rgb([pixel.r() as u8, pixel.g() as u8, pixel.b() as u8]),
+            );
         }
         bar.inc(1);
     }
 
-    let ref mut file = File::create(&path).unwrap();    
-    let _ = image::ImageRgb8(imgbuf).save(file, image::PNG);
-    
+    let _ = image::ImageRgb8(imgbuf).save(&path);
+
     bar.finish();
     println!("successfully wrote to {}", display);
 }
@@ -43,8 +45,14 @@ pub fn gen_ppm(img: Vec<Vec<Vec3>>, filename: String) -> () {
 fn test_gen_ppm() {
     fn lerp(r: &Ray) -> Vec3 {
         let unit_direction: Vec3 = r.direction().unit_vector();
-        let t: f64 = 0.5*(unit_direction.y() + 1.0);
-        (1.0 - t) * Vec3{elements:[1.0, 1.0, 1.0]} + t * Vec3{elements:[0.5, 0.7, 1.0]}
+        let t: f64 = 0.5 * (unit_direction.y() + 1.0);
+        (1.0 - t)
+            * Vec3 {
+                elements: [1.0, 1.0, 1.0],
+            }
+            + t * Vec3 {
+                elements: [0.5, 0.7, 1.0],
+            }
     }
 
     let origin: Vec3 = Vec3::new(0.0, 0.0, 0.0);
@@ -58,14 +66,15 @@ fn test_gen_ppm() {
     for y in (0..ny).rev() {
         let mut row: Vec<Vec3> = Vec::new();
         for x in 0..nx {
-            let u: f64 = x as f64/nx as f64;
-            let v: f64 = y as f64/ny as f64;
-            let r: Ray = Ray::new(origin,
-                                  lower_left_corner + u*horizontal + v*vertical);
+            let u: f64 = x as f64 / nx as f64;
+            let v: f64 = y as f64 / ny as f64;
+            let r: Ray = Ray::new(origin, lower_left_corner + u * horizontal + v * vertical);
             let col: Vec3 = lerp(&r);
-            let color_vector = Vec3::new((255.99*col.r()).floor(),
-                                         (255.99*col.g()).floor(),
-                                         (255.99*col.b()).floor());
+            let color_vector = Vec3::new(
+                (255.99 * col.r()).floor(),
+                (255.99 * col.g()).floor(),
+                (255.99 * col.b()).floor(),
+            );
             row.push(color_vector);
         }
         bg.push(row);
@@ -74,5 +83,4 @@ fn test_gen_ppm() {
     let filename = "test.png".to_string();
     gen_ppm(bg, filename);
     assert!(true);
-
 }


### PR DESCRIPTION
Hi,
sorry for the noise due to the formater, the main point of the PR is to fix the following call:
from `ImageRgb8(imgbuf).save(file, image::PNG)` 
to `image::ImageRgb8(imgbuf).save(&path)`

The API must have changed, the type of file is now inferred based on the file extension
